### PR TITLE
[bench] add benchmarks for `expected_*_equation` methods

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^vignettes/articles$
 ^vignettes/Portfolio-CDS-and-CDO-tranches\.Rmd$
 ^codemeta\.json$
+^bench$

--- a/.github/workflows/continuous-benchmarks.yaml
+++ b/.github/workflows/continuous-benchmarks.yaml
@@ -1,0 +1,31 @@
+on:
+  [push, pull_request]
+
+name: Continuous Benchmarks
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@master
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@master
+
+      - name: Install dependencies
+        run: |
+          Rscript -e "install.packages(c('remotes'))" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_github('r-lib/bench')"
+          R CMD INSTALL .
+
+      - name: Fetch existing benchmarks
+        run: Rscript -e 'bench::cb_fetch()'
+
+      - name: Run benchmarks
+        run: Rscript -e 'bench::cb_run()'
+
+      - name: Show benchmarks
+        run: git notes --ref benchmarks show
+
+      - name: Push benchmarks
+        run: Rscript -e "bench::cb_push()"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ LinkingTo:
 Suggests:
     testthat (>= 3.0.0),
     covr,
-    rmarkdown
+    rmarkdown,
+    bench
 Config/testthat/edition: 3
 Collate:
     'RcppExports.R'

--- a/R/s4-ExMOParam.R
+++ b/R/s4-ExMOParam.R
@@ -124,7 +124,7 @@ setMethod("initialize", "ExMOParam",
 #' @export
 setMethod("simulate_dt", "ExMOParam",
   function(object, ...,
-      method = c("default", "ExMOParam", "ExMarkovParam"), n_sim = 1e1L) {
+      method = c("default", "ExMOParam", "ExMarkovParam"), n_sim = 1e4L) {
     method <- match.arg(method)
     if (isTRUE("default" == method)) {
       method <- "ExMOParam"

--- a/R/s4-ExMarkovParam.R
+++ b/R/s4-ExMarkovParam.R
@@ -113,7 +113,7 @@ setMethod("initialize", "ExMarkovParam",
 #' @export
 setMethod("simulate_dt", "ExMarkovParam",
   function(object, ...,
-      method = c("default", "ExMarkovParam"), n_sim = 1e1L) {
+      method = c("default", "ExMarkovParam"), n_sim = 1e4L) {
     method <- match.arg(method)
     d <- getDimension(object)
     ex_qmatrix <- getExQMatrix(object)

--- a/R/s4-ExtArch2FParam.R
+++ b/R/s4-ExtArch2FParam.R
@@ -322,7 +322,7 @@ setMethod("invTau", "ExtArch2FParam",
 #' @include utils.R
 setMethod("simulate_dt", "ExtArch2FParam",
   function(object, ...,
-      method = c("default", "ExtArch2fParam"), n_sim = 1e1L) {
+      method = c("default", "ExtArch2fParam"), n_sim = 1e4L) {
     method <- match.arg(method)
     out <- qexp(
       rCopula(n_sim, getCopula(object)),

--- a/R/s4-ExtGaussian2FParam.R
+++ b/R/s4-ExtGaussian2FParam.R
@@ -180,7 +180,7 @@ setMethod("initialize", signature = "ExtGaussian2FParam",
 #' @export
 setMethod("simulate_dt", "ExtGaussian2FParam",
   function(object, ...,
-      method = c("default", "ExtGaussian2FParam"), n_sim = 1e1L) {
+      method = c("default", "ExtGaussian2FParam"), n_sim = 1e4L) {
     method <- match.arg(method)
     normalCopula(param = getNu(object), dim = getDimension(object), dispstr = "ex") %>%
       rCopula(n_sim, .) %>%

--- a/R/s4-H2ExMarkovParam.R
+++ b/R/s4-H2ExMarkovParam.R
@@ -172,6 +172,7 @@ setMethod("initialize", "H2ExMarkovParam",
 #'    simulates the vector of *default times* and returns a matrix `x` with
 #'    `dim(x) == c(n_sim, getDimension(object))`.
 #' @aliases simulate_dt,H2ExMarkovParam-method
+#' @param n_sim Number of samples.
 #'
 #' @inheritParams simulate_dt
 #'
@@ -193,10 +194,10 @@ setMethod("initialize", "H2ExMarkovParam",
 #'
 #' @include utils.R
 setMethod("simulate_dt", "H2ExMarkovParam",
-  function(object, ...) {
+  function(object, ..., n_sim = 1e4L) {
     fraction <- getFraction(object)
-    dt_global <- simulate_dt(getGlobalModel(object), ...)
-    dt_partition <- map(getPartitionModels(object), simulate_dt, ...) %>%
+    dt_global <- simulate_dt(getGlobalModel(object), ..., n_sim = n_sim)
+    dt_partition <- map(getPartitionModels(object), simulate_dt, ..., n_sim = n_sim) %>%
       reduce(cbind) %>%
       `dimnames<-`(NULL)
 

--- a/R/s4-H2ExtArch3FParam.R
+++ b/R/s4-H2ExtArch3FParam.R
@@ -388,7 +388,7 @@ setMethod("show", "H2ExtArch3FParam",
 #' @importFrom copula rCopula
 #' @include utils.R
 setMethod("simulate_dt", "H2ExtArch3FParam",
-  function(object, ..., n_sim = 1e4) {
+  function(object, ..., n_sim = 1e4L) {
     rCopula(n_sim, getCopula(object)) %>%
       qexp(rate = getLambda(object), lower.tail = !getSurvival(object))
   })

--- a/R/s4-H2ExtGaussian3FParam.R
+++ b/R/s4-H2ExtGaussian3FParam.R
@@ -226,7 +226,7 @@ setMethod("initialize", "H2ExtGaussian3FParam",
 #' @importFrom stats qexp
 #' @include utils.R
 setMethod("simulate_dt", "H2ExtGaussian3FParam",
-  function(object, ..., n_sim = 1e4) {
+  function(object, ..., n_sim = 1e4L) {
     d <- getDimension(object)
     lambda <- getLambda(object)
     nu <- getNu(object)

--- a/bench/expected_cdo_equation_default.R
+++ b/bench/expected_cdo_equation_default.R
@@ -1,5 +1,5 @@
-#+ r load-all
-pkgload::load_all()
+#+ r load-package
+library(cvalr)
 
 #+ r config-and-setup
 times <- seq(0.25, 5, by = 0.25)

--- a/bench/expected_cdo_equation_default.R
+++ b/bench/expected_cdo_equation_default.R
@@ -1,0 +1,86 @@
+#+ r load-all
+pkgload::load_all()
+
+#+ r config-and-setup
+times <- seq(0.25, 5, by = 0.25)
+discount_factors <- rep(1, length(times))
+recovery_rate <- 4e-1
+lower <- c(0, 0.1, 0.2, 0.35)
+upper <- c(0.1, 0.2, 0.35, 1)
+coupon <- c(rep(5e-2, 3), 0)
+upfront <- c(8e-1, 5e-1, 1e-1, 0)
+
+composition <- c(28, 24, 16, 4, 3)
+dim <- sum(composition)
+lambda <- 8e-2
+tau1 <- 4e-1
+tau2 <- c(3e-2, 6e-2)
+
+parm_caextmo2f <- CuadrasAugeExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_asextmo2f <- AlphaStableExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_poextmo2f <- PoissonExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_exextmo2f <- ExponentialExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+parm_extga2f <- ExtGaussian2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+parm_clextar2f <- ClaytonExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_frextar2f <- FrankExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_guextar2f <- GumbelExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_joextar2f <- JoeExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+
+parm_cah2extmo3f <- CuadrasAugeH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_ash2extmo3f <- AlphaStableH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_poh2extmo3f <- PoissonH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_exh2extmo3f <- ExponentialH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+
+parm_h2extga3f <- H2ExtGaussian3FParam(composition = composition, lambda = lambda, tau = tau2)
+
+parm_clh2extar3f <- ClaytonH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_frh2extar3f <- FrankH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_guh2extar3f <- GumbelH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_joh2extar3f <- JoeH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+
+bench::mark(
+  CuadrasAugeExtMO2FParam = expected_cdo_equation(
+    parm_caextmo2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  AlphaStableExtMO2FParam = expected_cdo_equation(
+    parm_asextmo2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  PoissonExtMO2FParam = expected_cdo_equation(
+    parm_poextmo2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  ExponentialExtMO2FParam = expected_cdo_equation(
+    parm_exextmo2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  ExtGaussianMO2FParam = expected_cdo_equation(
+    parm_extga2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  ClaytonExtArch2FParam = expected_cdo_equation(
+    parm_clextar2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  FrankExtArch2FParam = expected_cdo_equation(
+    parm_frextar2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  GumbelExtArch2FParam = expected_cdo_equation(
+    parm_guextar2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  JoeExtArch2FParam = expected_cdo_equation(
+    parm_joextar2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  CuadrasAugeH2ExtMO3FParam = expected_cdo_equation(
+    parm_cah2extmo3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  AlphaStableH2ExtMO3FParam = expected_cdo_equation(
+    parm_ash2extmo3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  PoissonH2ExtMO3FParam = expected_cdo_equation(
+    parm_poh2extmo3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  ExponentialH2ExtMO3FParam = expected_cdo_equation(
+    parm_exh2extmo3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  H2ExtGaussianMO3FParam = expected_cdo_equation(
+    parm_h2extga3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  ClaytonH2ExtArch3FParam = expected_cdo_equation(
+    parm_clh2extar3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  FrankH2ExtArch3FParam = expected_cdo_equation(
+    parm_frh2extar3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  GumbelH2ExtArch3FParam = expected_cdo_equation(
+    parm_guh2extar3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  JoeH2ExtArch3FParam = expected_cdo_equation(
+    parm_joh2extar3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront),
+  min_time = 1, min_iterations = 1L, check = FALSE
+)

--- a/bench/expected_cdo_equation_mc.R
+++ b/bench/expected_cdo_equation_mc.R
@@ -1,5 +1,5 @@
-#+ r load-all
-pkgload::load_all()
+#+ r load-package
+library(cvalr)
 
 #+ r config-and-setup
 pd_args <- list(method = "CalibrationParam", sim_args = list(n_sim = 1e4))

--- a/bench/expected_cdo_equation_mc.R
+++ b/bench/expected_cdo_equation_mc.R
@@ -1,0 +1,105 @@
+#+ r load-all
+pkgload::load_all()
+
+#+ r config-and-setup
+pd_args <- list(method = "CalibrationParam", sim_args = list(n_sim = 1e4))
+times <- seq(0.25, 5, by = 0.25)
+discount_factors <- rep(1, length(times))
+recovery_rate <- 4e-1
+lower <- c(0, 0.1, 0.2, 0.35)
+upper <- c(0.1, 0.2, 0.35, 1)
+coupon <- c(rep(5e-2, 3), 0)
+upfront <- c(8e-1, 5e-1, 1e-1, 0)
+
+composition <- c(28, 24, 16, 4, 3)
+dim <- sum(composition)
+lambda <- 8e-2
+tau1 <- 4e-1
+tau2 <- c(3e-2, 6e-2)
+
+parm_caextmo2f <- CuadrasAugeExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_asextmo2f <- AlphaStableExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_poextmo2f <- PoissonExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_exextmo2f <- ExponentialExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+parm_extga2f <- ExtGaussian2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+parm_clextar2f <- ClaytonExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_frextar2f <- FrankExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_guextar2f <- GumbelExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_joextar2f <- JoeExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+
+parm_cah2extmo3f <- CuadrasAugeH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_ash2extmo3f <- AlphaStableH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_poh2extmo3f <- PoissonH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_exh2extmo3f <- ExponentialH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+
+parm_h2extga3f <- H2ExtGaussian3FParam(composition = composition, lambda = lambda, tau = tau2)
+
+parm_clh2extar3f <- ClaytonH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_frh2extar3f <- FrankH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_guh2extar3f <- GumbelH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_joh2extar3f <- JoeH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+
+bench::mark(
+  CuadrasAugeExtMO2FParam = expected_cdo_equation(
+    parm_caextmo2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  AlphaStableExtMO2FParam = expected_cdo_equation(
+    parm_asextmo2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  PoissonExtMO2FParam = expected_cdo_equation(
+    parm_poextmo2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  ExponentialExtMO2FParam = expected_cdo_equation(
+    parm_exextmo2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  ExtGaussianMO2FParam = expected_cdo_equation(
+    parm_extga2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  ClaytonExtArch2FParam = expected_cdo_equation(
+    parm_clextar2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  FrankExtArch2FParam = expected_cdo_equation(
+    parm_frextar2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  GumbelExtArch2FParam = expected_cdo_equation(
+    parm_guextar2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  JoeExtArch2FParam = expected_cdo_equation(
+    parm_joextar2f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  CuadrasAugeH2ExtMO3FParam = expected_cdo_equation(
+    parm_cah2extmo3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  AlphaStableH2ExtMO3FParam = expected_cdo_equation(
+    parm_ash2extmo3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  PoissonH2ExtMO3FParam = expected_cdo_equation(
+    parm_poh2extmo3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  ExponentialH2ExtMO3FParam = expected_cdo_equation(
+    parm_exh2extmo3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  H2ExtGaussianMO3FParam = expected_cdo_equation(
+    parm_h2extga3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  ClaytonH2ExtArch3FParam = expected_cdo_equation(
+    parm_clh2extar3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  FrankH2ExtArch3FParam = expected_cdo_equation(
+    parm_frh2extar3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  GumbelH2ExtArch3FParam = expected_cdo_equation(
+    parm_guh2extar3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  JoeH2ExtArch3FParam = expected_cdo_equation(
+    parm_joh2extar3f, times, discount_factors, recovery_rate, lower, upper, coupon, upfront,
+    method = "CalibrationParam", pd_args = pd_args),
+  min_time = 1, min_iterations = 1L, check = FALSE
+)

--- a/bench/expected_pcds_equation_default.R
+++ b/bench/expected_pcds_equation_default.R
@@ -1,0 +1,83 @@
+#+ r load-all
+pkgload::load_all()
+
+#+ r config-and-setup
+times <- seq(0.25, 5, by = 0.25)
+discount_factors <- rep(1, length(times))
+recovery_rate <- 4e-1
+spread <- 6e-2
+
+composition <- c(28, 24, 16, 4, 3)
+dim <- sum(composition)
+lambda <- 8e-2
+tau1 <- 4e-1
+tau2 <- c(3e-2, 6e-2)
+
+parm_caextmo2f <- CuadrasAugeExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_asextmo2f <- AlphaStableExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_poextmo2f <- PoissonExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_exextmo2f <- ExponentialExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+parm_extga2f <- ExtGaussian2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+parm_clextar2f <- ClaytonExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_frextar2f <- FrankExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_guextar2f <- GumbelExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_joextar2f <- JoeExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+
+parm_cah2extmo3f <- CuadrasAugeH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_ash2extmo3f <- AlphaStableH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_poh2extmo3f <- PoissonH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_exh2extmo3f <- ExponentialH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+
+parm_h2extga3f <- H2ExtGaussian3FParam(composition = composition, lambda = lambda, tau = tau2)
+
+parm_clh2extar3f <- ClaytonH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_frh2extar3f <- FrankH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_guh2extar3f <- GumbelH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_joh2extar3f <- JoeH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+
+bench::mark(
+  CuadrasAugeExtMO2FParam = expected_pcds_equation(
+    parm_caextmo2f, times, discount_factors, recovery_rate, spread, 0),
+  AlphaStableExtMO2FParam = expected_pcds_equation(
+    parm_asextmo2f, times, discount_factors, recovery_rate, spread, 0),
+  PoissonExtMO2FParam = expected_pcds_equation(
+    parm_poextmo2f, times, discount_factors, recovery_rate, spread, 0),
+  ExponentialExtMO2FParam = expected_pcds_equation(
+    parm_exextmo2f, times, discount_factors, recovery_rate, spread, 0),
+  ExtGaussianMO2FParam = expected_pcds_equation(
+    parm_extga2f, times, discount_factors, recovery_rate, spread, 0),
+  ClaytonExtArch2FParam = expected_pcds_equation(
+    parm_clextar2f, times, discount_factors, recovery_rate, spread, 0),
+  FrankExtArch2FParam = expected_pcds_equation(
+    parm_frextar2f, times, discount_factors, recovery_rate, spread, 0),
+  GumbelExtArch2FParam = expected_pcds_equation(
+    parm_guextar2f, times, discount_factors, recovery_rate, spread, 0),
+  JoeExtArch2FParam = expected_pcds_equation(
+    parm_joextar2f, times, discount_factors, recovery_rate, spread, 0),
+  CuadrasAugeH2ExtMO3FParam = expected_pcds_equation(
+    parm_cah2extmo3f, times, discount_factors, recovery_rate, spread, 0),
+  AlphaStableH2ExtMO3FParam = expected_pcds_equation(
+    parm_ash2extmo3f, times, discount_factors, recovery_rate, spread, 0),
+  PoissonH2ExtMO3FParam = expected_pcds_equation(
+    parm_poh2extmo3f, times, discount_factors, recovery_rate, spread, 0),
+  ExponentialH2ExtMO3FParam = expected_pcds_equation(
+    parm_exh2extmo3f, times, discount_factors, recovery_rate, spread, 0),
+  H2ExtGaussianMO3FParam = expected_pcds_equation(
+    parm_h2extga3f, times, discount_factors, recovery_rate, spread, 0),
+  ClaytonH2ExtArch3FParam = expected_pcds_equation(
+    parm_clh2extar3f, times, discount_factors, recovery_rate, spread, 0),
+  FrankH2ExtArch3FParam = expected_pcds_equation(
+    parm_frh2extar3f, times, discount_factors, recovery_rate, spread, 0),
+  GumbelH2ExtArch3FParam = expected_pcds_equation(
+    parm_guh2extar3f, times, discount_factors, recovery_rate, spread, 0),
+  JoeH2ExtArch3FParam = expected_pcds_equation(
+    parm_joh2extar3f, times, discount_factors, recovery_rate, spread, 0),
+  min_time = 1, min_iterations = 1L, check = FALSE
+)

--- a/bench/expected_pcds_equation_default.R
+++ b/bench/expected_pcds_equation_default.R
@@ -1,5 +1,5 @@
-#+ r load-all
-pkgload::load_all()
+#+ r load-package
+library(cvalr)
 
 #+ r config-and-setup
 times <- seq(0.25, 5, by = 0.25)

--- a/bench/expected_pcds_equation_mc.R
+++ b/bench/expected_pcds_equation_mc.R
@@ -1,5 +1,5 @@
-#+ r load-all
-pkgload::load_all()
+#+ r load-package
+library(cvalr)
 
 #+ r config-and-setup
 pd_args <- list(method = "CalibrationParam", sim_args = list(n_sim = 1e4))

--- a/bench/expected_pcds_equation_mc.R
+++ b/bench/expected_pcds_equation_mc.R
@@ -1,0 +1,102 @@
+#+ r load-all
+pkgload::load_all()
+
+#+ r config-and-setup
+pd_args <- list(method = "CalibrationParam", sim_args = list(n_sim = 1e4))
+times <- seq(0.25, 5, by = 0.25)
+discount_factors <- rep(1, length(times))
+recovery_rate <- 4e-1
+spread <- 6e-2
+
+composition <- c(28, 24, 16, 4, 3)
+dim <- sum(composition)
+lambda <- 8e-2
+tau1 <- 4e-1
+tau2 <- c(3e-2, 6e-2)
+
+parm_caextmo2f <- CuadrasAugeExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_asextmo2f <- AlphaStableExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_poextmo2f <- PoissonExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_exextmo2f <- ExponentialExtMO2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+parm_extga2f <- ExtGaussian2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+parm_clextar2f <- ClaytonExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_frextar2f <- FrankExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_guextar2f <- GumbelExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+parm_joextar2f <- JoeExtArch2FParam(dim = dim, lambda = lambda, tau = tau1)
+
+
+parm_cah2extmo3f <- CuadrasAugeH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_ash2extmo3f <- AlphaStableH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_poh2extmo3f <- PoissonH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+parm_exh2extmo3f <- ExponentialH2ExtMO3FParam(
+  composition = composition, lambda = lambda, tau = tau2)
+
+parm_h2extga3f <- H2ExtGaussian3FParam(composition = composition, lambda = lambda, tau = tau2)
+
+parm_clh2extar3f <- ClaytonH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_frh2extar3f <- FrankH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_guh2extar3f <- GumbelH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+parm_joh2extar3f <- JoeH2ExtArch3FParam(composition = composition, lambda = lambda, tau = tau2)
+
+bench::mark(
+  CuadrasAugeExtMO2FParam = expected_pcds_equation(
+    parm_caextmo2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  AlphaStableExtMO2FParam = expected_pcds_equation(
+    parm_asextmo2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  PoissonExtMO2FParam = expected_pcds_equation(
+    parm_poextmo2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  ExponentialExtMO2FParam = expected_pcds_equation(
+    parm_exextmo2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  ExtGaussianMO2FParam = expected_pcds_equation(
+    parm_extga2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  ClaytonExtArch2FParam = expected_pcds_equation(
+    parm_clextar2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  FrankExtArch2FParam = expected_pcds_equation(
+    parm_frextar2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  GumbelExtArch2FParam = expected_pcds_equation(
+    parm_guextar2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  JoeExtArch2FParam = expected_pcds_equation(
+    parm_joextar2f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  CuadrasAugeH2ExtMO3FParam = expected_pcds_equation(
+    parm_cah2extmo3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  AlphaStableH2ExtMO3FParam = expected_pcds_equation(
+    parm_ash2extmo3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  PoissonH2ExtMO3FParam = expected_pcds_equation(
+    parm_poh2extmo3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  ExponentialH2ExtMO3FParam = expected_pcds_equation(
+    parm_exh2extmo3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  H2ExtGaussianMO3FParam = expected_pcds_equation(
+    parm_h2extga3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  ClaytonH2ExtArch3FParam = expected_pcds_equation(
+    parm_clh2extar3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  FrankH2ExtArch3FParam = expected_pcds_equation(
+    parm_frh2extar3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  GumbelH2ExtArch3FParam = expected_pcds_equation(
+    parm_guh2extar3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  JoeH2ExtArch3FParam = expected_pcds_equation(
+    parm_joh2extar3f, times, discount_factors, recovery_rate, spread, 0,
+    method = "CalibrationParam", pd_args = pd_args),
+  min_time = 1, min_iterations = 1L, check = FALSE
+)

--- a/man/ExMOParam-class.Rd
+++ b/man/ExMOParam-class.Rd
@@ -16,7 +16,7 @@
   object,
   ...,
   method = c("default", "ExMOParam", "ExMarkovParam"),
-  n_sim = 10L
+  n_sim = 10000L
 )
 
 \S4method{show}{ExMOParam}(object)

--- a/man/ExMarkovParam-class.Rd
+++ b/man/ExMarkovParam-class.Rd
@@ -23,7 +23,12 @@
 
 \S4method{initialize}{ExMarkovParam}(.Object, ex_qmatrix)
 
-\S4method{simulate_dt}{ExMarkovParam}(object, ..., method = c("default", "ExMarkovParam"), n_sim = 10L)
+\S4method{simulate_dt}{ExMarkovParam}(
+  object,
+  ...,
+  method = c("default", "ExMarkovParam"),
+  n_sim = 10000L
+)
 
 \S4method{probability_distribution}{ExMarkovParam}(
   object,

--- a/man/ExtArch2FParam-class.Rd
+++ b/man/ExtArch2FParam-class.Rd
@@ -38,7 +38,12 @@
   family = c("Clayton", "Frank", "Gumbel", "Joe")
 )
 
-\S4method{simulate_dt}{ExtArch2FParam}(object, ..., method = c("default", "ExtArch2fParam"), n_sim = 10L)
+\S4method{simulate_dt}{ExtArch2FParam}(
+  object,
+  ...,
+  method = c("default", "ExtArch2fParam"),
+  n_sim = 10000L
+)
 
 \S4method{expected_pcds_loss}{ExtArch2FParam}(
   object,

--- a/man/ExtGaussian2FParam-class.Rd
+++ b/man/ExtGaussian2FParam-class.Rd
@@ -18,7 +18,7 @@
   object,
   ...,
   method = c("default", "ExtGaussian2FParam"),
-  n_sim = 10L
+  n_sim = 10000L
 )
 
 \S4method{probability_distribution}{ExtGaussian2FParam}(

--- a/man/H2ExMarkovParam-class.Rd
+++ b/man/H2ExMarkovParam-class.Rd
@@ -12,7 +12,7 @@
 \usage{
 \S4method{initialize}{H2ExMarkovParam}(.Object, fraction, models)
 
-\S4method{simulate_dt}{H2ExMarkovParam}(object, ...)
+\S4method{simulate_dt}{H2ExMarkovParam}(object, ..., n_sim = 10000L)
 
 \S4method{show}{H2ExMarkovParam}(object)
 }
@@ -27,6 +27,8 @@
 \item{object}{A \linkS4class{CalibrationParam}-object.}
 
 \item{...}{Pass-through parameters.}
+
+\item{n_sim}{Number of samples.}
 }
 \description{
 \linkS4class{CalibrationParam} for the H2-exchangeable Markovian \emph{(average) default counting process}

--- a/man/H2ExtArch3FParam-class.Rd
+++ b/man/H2ExtArch3FParam-class.Rd
@@ -36,7 +36,7 @@
   family = c("Clayton", "Frank", "Gumbel", "Joe")
 )
 
-\S4method{simulate_dt}{H2ExtArch3FParam}(object, ..., n_sim = 10000)
+\S4method{simulate_dt}{H2ExtArch3FParam}(object, ..., n_sim = 10000L)
 
 \S4method{initialize}{ClaytonH2ExtArch3FParam}(.Object, ..., survival = FALSE)
 

--- a/man/H2ExtGaussian3FParam-class.Rd
+++ b/man/H2ExtGaussian3FParam-class.Rd
@@ -21,7 +21,7 @@
   tau = NULL
 )
 
-\S4method{simulate_dt}{H2ExtGaussian3FParam}(object, ..., n_sim = 10000)
+\S4method{simulate_dt}{H2ExtGaussian3FParam}(object, ..., n_sim = 10000L)
 
 \S4method{show}{H2ExtGaussian3FParam}(object)
 


### PR DESCRIPTION
## Related issues

Closes #29

## Checklist

- [x] `R CMD CHECK` successful
- [ ] tests included
- [ ] documentation included or updated
- [x] commit messages follow [commit guidelines](https://udacity.github.io/git-styleguide/)

Only for new or refactored algorithms:

- [ ] benchmarks (and comparison with the previous version) included

Optional, but recommended:

- [x] code passes `lintr::lint_package()` without errors

## Description

Provide benchmarks for `expect_*_equation` methods for the default case and the Monte-Carlo case.